### PR TITLE
Support for object as props to css-constructor

### DIFF
--- a/api.js
+++ b/api.js
@@ -59,11 +59,16 @@ let fillProps = (rawCSS, props) => {
     let matches = rawCSS.match(re);
     if (matches && matches.length) {
         for (let match of matches) {
-            let keyword = match;
+            let keyword = match, replaceWord, propKeys;
             keyword = keyword.replace('{this.props.', '');
             keyword = keyword.substring(0, keyword.length-1); // remove }
             keyword = keyword.trim();
-            rawCSS = rawCSS.replace(match, props[keyword]);
+            replaceWord = props;
+            propKeys = keyword.split('.');
+            for (let i = 0; i < propKeys.length; i++) {
+                replaceWord = replaceWord[propKeys[i]];
+            }
+            rawCSS = rawCSS.replace(match, replaceWord);
         }
     }
     return rawCSS;

--- a/example/entry.js
+++ b/example/entry.js
@@ -2,7 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Hello from './hello';
 
+let color = {
+	sampleColor: 'papayawhip'
+}
+
 ReactDOM.render(
-    <Hello color='papayawhip'/>,
+    <Hello color={color} />,
     document.getElementById('container')
 );

--- a/example/hello.js
+++ b/example/hello.js
@@ -15,7 +15,7 @@ export default class Hello extends React.Component {
         text-align: center;
 
         /* Use props in your CSS */
-        color: {this.props.color};
+        color: {this.props.color.sampleColor};
 
         /* Pseudo selectors */
         &:hover {


### PR DESCRIPTION
### Why ?
1. To allow passing of objects as props to css-constructor.

### What ?
Modified the fillProps function to accept object as props.